### PR TITLE
Fix dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -162,4 +162,3 @@ shippable
 .git
 
 tmp/
-tests/


### PR DESCRIPTION
When deploying to Cloud Run, this error triggered: `ModuleNotFoundError: No module named python container tests`

This is because `tests/` is in the `.dockerignore`. 
